### PR TITLE
added EQ support 

### DIFF
--- a/integration/homeassistant/mqtt.yaml
+++ b/integration/homeassistant/mqtt.yaml
@@ -10,6 +10,61 @@ number:
     max: 100
     unit_of_measurement: "%"
     icon: "mdi:volume-high"
+    
+  - unique_id: soundsend_eq_high
+    device: !include inc/soundsend_device.yaml
+    name: SoundSend EQ High
+    state_topic: "wisa2mqtt/status/eq_high"
+    command_topic: "wisa2mqtt/command/setEqHigh"
+    availability: !include inc/soundsend_availability.yaml
+    mode: slider
+    min: -6
+    max: 6
+    icon: "mdi:equalizer"
+
+  - unique_id: soundsend_eq_midrange
+    device: !include inc/soundsend_device.yaml
+    name: SoundSend EQ Mid-Range
+    state_topic: "wisa2mqtt/status/eq_midrange"
+    command_topic: "wisa2mqtt/command/setEqMidrange"
+    availability: !include inc/soundsend_availability.yaml
+    mode: slider
+    min: -6
+    max: 6
+    icon: "mdi:equalizer"
+
+  - unique_id: soundsend_eq_voice
+    device: !include inc/soundsend_device.yaml
+    name: SoundSend EQ Voice
+    state_topic: "wisa2mqtt/status/eq_voice"
+    command_topic: "wisa2mqtt/command/setEqVoice"
+    availability: !include inc/soundsend_availability.yaml
+    mode: slider
+    min: -6
+    max: 6
+    icon: "mdi:equalizer"
+
+  - unique_id: soundsend_eq_midbass
+    device: !include inc/soundsend_device.yaml
+    name: SoundSend EQ Mid-Bass
+    state_topic: "wisa2mqtt/status/eq_midbass"
+    command_topic: "wisa2mqtt/command/setEqMidbass"
+    availability: !include inc/soundsend_availability.yaml
+    mode: slider
+    min: -6
+    max: 6
+    icon: "mdi:equalizer"
+
+  - unique_id: soundsend_eq_subbass
+    device: !include inc/soundsend_device.yaml
+    name: SoundSend EQ Sub-Bass
+    state_topic: "wisa2mqtt/status/eq_subbass"
+    command_topic: "wisa2mqtt/command/setEqSubbass"
+    availability: !include inc/soundsend_availability.yaml
+    mode: slider
+    min: -6
+    max: 6
+    icon: "mdi:equalizer"
 
 select:
   - unique_id: soundsend_audio_mode

--- a/src/command-handler.js
+++ b/src/command-handler.js
@@ -57,6 +57,22 @@ async function handleCommand(soundSend, command, arg) {
       case 'togglebassmanagement':
         await soundSend.toggleBassManagement();
         break;
+
+      case 'setEqHigh':
+        await soundSend.setEqHigh(arg);
+        break;
+      case 'setEqSubbass':
+        await soundSend.setEqSubbass(arg);
+        break;
+      case 'setEqVoice':
+        await soundSend.setEqVoice(arg);
+        break;
+      case 'setEqMidrange':
+        await soundSend.setEqMidrange(arg);
+        break;
+      case 'setEqMidbass':
+        await soundSend.setEqMidbass(arg);
+        break;        
       default:
         throw new Error('Unknown command');
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,4 +11,69 @@ async function retryPromise(fn, minInterval, maxInterval) {
   }
 }
 
-module.exports = {retryPromise};
+function mapEqGainToByte(gain) {
+  gain = Number(gain);
+  if (!Number.isInteger(gain) || gain < -6 || gain > 6) {
+    throw new Error('gain must be integer between -6 and 6');
+  }
+
+  const explicit = {
+    '-6': 250,
+    '-5': 251,
+    '-4': 252,
+    '-3': 253,
+    '-2': 254,
+    '-1': 255,
+    '0':   0,
+    '1':   1,
+    '2':   2,
+    '3':   3,
+    '4':   4,
+    '5':   5,
+    '6':   6
+  };
+
+  if (explicit.hasOwnProperty(String(gain))) {
+    return explicit[String(gain)];
+  }
+  return gain;
+}
+
+
+function mapByteToEqGain(byte) {
+  const b = Number(byte);
+  if (!Number.isInteger(b) || b < 0 || b > 255) {
+    throw new Error('byte must be integer 0..255');
+  }
+
+  const reverse = {
+    '250': -6,
+    '251': -5,
+    '252': -4,
+    '253': -3,
+    '254': -2,
+    '255': -1,
+    '0': 0,
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6
+  };
+  if (Object.prototype.hasOwnProperty.call(reverse, String(b))) {
+    return reverse[String(b)];
+  }
+
+  const signed = (b > 127) ? b - 256 : b;
+  if (signed >= -6 && signed <= 6) return signed;
+
+  if (b >= 0 && b <= 12) {
+    const gain = b - 6;
+    if (gain >= -6 && gain <= 6) return gain;
+  }
+
+  return null;
+}
+
+module.exports = {retryPromise, mapEqGainToByte, mapByteToEqGain};


### PR DESCRIPTION
the presets only work from an application on the device you have to use each band separately, so i have added 5 bands and exposed in home assistant (High, Mid-range, voice, mid-bass, and sub-bass). 
On the device you have values 0 to 6 and 255(-1) to 250  (-6).

I have tested and this works fomrHa as slider.
<img width="617" height="572" alt="image" src="https://github.com/user-attachments/assets/8021a89c-ec5b-46ab-a09b-e4c6fc5a0fa5" />
